### PR TITLE
fix: crontab not found

### DIFF
--- a/trafficcop.sh
+++ b/trafficcop.sh
@@ -74,7 +74,7 @@ migrate_files() {
 
 
 check_and_install_packages() {
-    local packages=("vnstat" "jq" "bc" "iproute2")
+    local packages=("vnstat" "jq" "bc" "iproute2" "cron")
     local need_install=false
 
     for package in "${packages[@]}"; do


### PR DESCRIPTION
部分精简安装的 Debian 12 下没有 `crontab` 命令，需要手动安装 `cron` 包，报错如下：

```bash
2024-12-01 23:30:53 bc 安装成功
2024-12-01 23:30:53 vnstat 版本: vnStat 2.10 by Teemu Toivola <tst at iki dot fi>
2024-12-01 23:30:53 主要网络接口: eth0
2024-12-01 23:30:53 vnstat 统计开始日期: 2024-12-01，在此之前的流量不会被纳入统计！
2024-12-01 23:30:53 开始初始化配置...
2024-12-01 23:30:53 正在检测主要网络接口...
检测到的主要网络接口是: eth0, 按Enter使用此接口，或输入新的接口名称:
2024-12-01 23:30:57 请选择流量统计模式：
2024-12-01 23:30:57 1. 只计算出站流量
2024-12-01 23:30:57 2. 只计算进站流量
2024-12-01 23:30:57 3. 出进站流量都计算
2024-12-01 23:30:57 4. 出站和进站流量只取大
请输入选择 (1-4): 3
请选择流量统计周期 (m/q/y，默认为m):
请输入周期起始日 (1-31，默认为1): 11
请输入流量限制 (GB): 4000
请输入容错范围 (GB): 400
2024-12-01 23:31:59 请选择限制模式：
2024-12-01 23:31:59 1. TC 模式（更灵活）
2024-12-01 23:31:59 2. 关机模式（更安全）
请输入选择 (1-2): 2
2024-12-01 23:32:03 配置已更新
/root/TrafficCop/traffic_monitor.sh: line 456: crontab: command not found
/root/TrafficCop/traffic_monitor.sh: line 459: crontab: command not found
2024-12-01 23:32:03 Crontab 已设置，每分钟运行一次
2024-12-01 23:32:03 初始配置完成，脚本将每分钟自动运行一次
2024-12-01 23:32:03 当前流量使用情况：
2024-12-01 23:32:03 周期开始日期: 2024-11-11, 周期结束日期: 2024-12-10
(standard_in) 1: illegal character: :
(standard_in) 1: syntax error
2024-12-01 23:32:03 当前统计周期: monthly (从 2024-11-11 开始)
2024-12-01 23:32:03 统计模式: total
2024-12-01 23:32:03 当前使用流量:  GB
2024-12-01 23:32:03 检查并限制流量：
2024-12-01 23:32:03 周期开始日期: 2024-11-11, 周期结束日期: 2024-12-10
(standard_in) 1: illegal character: :
(standard_in) 1: syntax error
2024-12-01 23:32:03 当前使用流量:  GB，限制流量: 3600 GB
(standard_in) 1: syntax error
2024-12-01 23:32:03 流量正常，清除所有限制
-----------------------------------------------------
```